### PR TITLE
Change a way to get questionnaire data

### DIFF
--- a/fixtures/overview.js
+++ b/fixtures/overview.js
@@ -1,0 +1,12 @@
+const overview = {
+  id: 1,
+  previousId: null,
+  nextId: 2,
+  type: 'overview',
+  content: {
+    title: '제목',
+    explanation: '설명',
+  },
+};
+
+export default overview;

--- a/fixtures/question.js
+++ b/fixtures/question.js
@@ -1,0 +1,15 @@
+const question = {
+  id: 2,
+  previousId: 1,
+  nextId: 3,
+  type: 'question',
+  content: {
+    question: '질문1',
+    answers: [
+      { id: 1, title: '답1' },
+      { id: 2, title: '답2' },
+    ],
+  },
+};
+
+export default question;

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -8,6 +8,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import App from './App';
 
+import question from '../fixtures/question';
+
 jest.mock('react-redux');
 
 const mockPush = jest.fn();
@@ -36,7 +38,7 @@ describe('App', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      currentTest: 1,
+      currentTest: question,
       selectedAnswer: null,
       savedAnswers: {},
     }));

--- a/src/components/TestContent.jsx
+++ b/src/components/TestContent.jsx
@@ -4,8 +4,8 @@ import Overview from './Overview';
 import Question from './Question';
 
 export default function TestContent({
-  type, content, selectedAnswer,
-  handleClickAnswer,
+  test: { type, content },
+  selectedAnswer, handleClickAnswer,
 }) {
   return (
     <>

--- a/src/components/TestContent.test.jsx
+++ b/src/components/TestContent.test.jsx
@@ -4,16 +4,16 @@ import { render } from '@testing-library/react';
 
 import TestContent from './TestContent';
 
-import CONTENT from '../../fixtures/content';
+import QUESTION from '../../fixtures/question';
+import OVERVIEW from '../../fixtures/overview';
 
 describe('TestContent', () => {
   const handleClickAnswer = jest.fn();
 
-  function renderTestContent({ type, content, selectedAnswer }) {
+  function renderTestContent({ test, selectedAnswer }) {
     return render((
       <TestContent
-        type={type}
-        content={content}
+        test={test}
         selectedAnswer={selectedAnswer}
         handleClickAnswer={handleClickAnswer}
       />
@@ -26,28 +26,24 @@ describe('TestContent', () => {
 
   context('when type is `overview`', () => {
     it('renders overview', () => {
-      const type = 'overview';
-      const content = { title: 'Day', explanation: '설명설명' };
+      const { content: { title, explanation } } = OVERVIEW;
 
       const { getByText } = renderTestContent({
-        type,
-        content,
+        test: OVERVIEW,
         selectedAnswer: null,
       });
 
-      expect(getByText(content.title)).not.toBeNull();
-      expect(getByText(content.explanation)).not.toBeNull();
+      expect(getByText(title)).not.toBeNull();
+      expect(getByText(explanation)).not.toBeNull();
     });
   });
 
   context('when type is `question` without a selected answer', () => {
     it('renders question', () => {
-      const type = 'question';
-      const { question, answers } = CONTENT;
+      const { content: { question, answers } } = QUESTION;
 
       const { getByText } = renderTestContent({
-        type,
-        content: CONTENT,
+        test: QUESTION,
         selectedAnswer: null,
       });
 
@@ -62,13 +58,11 @@ describe('TestContent', () => {
 
   context('when type is `question`', () => {
     it('renders question with `v` sign', () => {
-      const type = 'question';
-      const { question, answers } = CONTENT;
+      const { content: { question, answers } } = QUESTION;
       const selectedAnswer = 1;
 
       const { getByText } = renderTestContent({
-        type,
-        content: CONTENT,
+        test: QUESTION,
         selectedAnswer,
       });
 

--- a/src/containers/TestsContainer.jsx
+++ b/src/containers/TestsContainer.jsx
@@ -6,10 +6,10 @@ import TestContent from '../components/TestContent';
 import TestNavigationButtons from '../components/TestNavigationButtons';
 
 import {
-  setCurrentTest, setSelectedAnswer, saveAnswer,
+  setSelectedAnswer,
+  saveAnswer,
+  loadTest,
 } from '../slice';
-
-import { getTest } from '../services/api';
 
 import { get } from '../utils';
 
@@ -20,42 +20,43 @@ export default function TestsContainer() {
   const savedAnswers = useSelector(get('savedAnswers'));
   const currentTest = useSelector(get('currentTest'));
 
-  const { type, content } = getTest(currentTest);
-
   function handleClickAnswer(answerId) {
     dispatch(setSelectedAnswer(answerId));
   }
 
-  function handleClickBack() {
-    const answerBefore = savedAnswers[currentTest - 1] || null;
+  function handleClickBack({
+    test: { previousId }, answers,
+  }) {
+    const selectedId = answers[previousId] || null;
 
-    dispatch(setSelectedAnswer(answerBefore));
-
-    dispatch(setCurrentTest(currentTest - 1));
+    dispatch(setSelectedAnswer(selectedId));
+    dispatch(loadTest(previousId));
   }
 
-  function handleClickNext() {
-    if (type === 'question') {
-      dispatch(saveAnswer({
-        questionId: currentTest,
-        answerId: selectedAnswer,
-      }));
-      dispatch(setSelectedAnswer(null));
-    }
-    dispatch(setCurrentTest(currentTest + 1));
+  function handleClickNext({
+    test: { id, nextId }, answer,
+  }) {
+    dispatch(saveAnswer({ questionId: id, answerId: answer }));
+    dispatch(setSelectedAnswer(null));
+    dispatch(loadTest(nextId));
   }
 
   return (
     <>
       <TestContent
-        type={type}
-        content={content}
+        test={currentTest}
         selectedAnswer={selectedAnswer}
         handleClickAnswer={handleClickAnswer}
       />
       <TestNavigationButtons
-        handleClickBack={handleClickBack}
-        handleClickNext={handleClickNext}
+        handleClickBack={() => handleClickBack({
+          test: currentTest,
+          answers: savedAnswers,
+        })}
+        handleClickNext={() => handleClickNext({
+          test: currentTest,
+          answer: selectedAnswer,
+        })}
       />
     </>
   );

--- a/src/containers/TestsContainer.test.jsx
+++ b/src/containers/TestsContainer.test.jsx
@@ -6,48 +6,61 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import TestsContainer from './TestsContainer';
 
-import { setCurrentTest } from '../slice';
+import QUESTION from '../../fixtures/question';
 
 jest.mock('react-redux');
 
 describe('TestsContainer', () => {
   const dispatch = jest.fn();
 
-  const currentTest = 2;
-  const selectedAnswer = 1;
-  const savedAnswers = {};
-
   const renderTestsContainer = () => render((
     <TestsContainer />
   ));
 
   beforeEach(() => {
+    dispatch.mockClear();
+
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      currentTest,
-      selectedAnswer,
-      savedAnswers,
+      currentTest: QUESTION,
+      selectedAnswer: null,
+      savedAnswers: {},
     }));
   });
 
+  context('when an answer button is clicked', () => {
+    it('dispatches setSelectedAnswer`', () => {
+      const { getByText } = renderTestsContainer();
+
+      const { content: { answers } } = QUESTION;
+
+      fireEvent.click(getByText(answers[0].title));
+
+      expect(dispatch).toBeCalledWith({
+        payload: answers[0].id,
+        type: 'application/setSelectedAnswer',
+      });
+    });
+  });
+
   context('when `back` button is clicked', () => {
-    it('dispatches setCurrentTest with `currentTest - 1`', () => {
+    it('dispatches setSelectedAnswer and loadTest`', () => {
       const { getByText } = renderTestsContainer();
 
       fireEvent.click(getByText(/back/));
 
-      expect(dispatch).toBeCalledWith(setCurrentTest(currentTest - 1));
+      expect(dispatch).toBeCalledTimes(2);
     });
   });
 
   context('when `next` button is clicked', () => {
-    it('dispatches setCurrentTest with `currentTest + 1`', () => {
+    it('dispatches saveAnswer, setSelctedAnswer, and loadTest`', () => {
       const { getByText } = renderTestsContainer();
 
       fireEvent.click(getByText(/next/));
 
-      expect(dispatch).toBeCalledWith(setCurrentTest(currentTest + 1));
+      expect(dispatch).toBeCalledTimes(3);
     });
   });
 });

--- a/src/data/questionnaire.js
+++ b/src/data/questionnaire.js
@@ -3,6 +3,8 @@
 const questionnaire = [
   {
     id: 1,
+    previousId: null,
+    nextId: 2,
     type: 'overview',
     content: {
       title: 'Day1,',
@@ -11,6 +13,8 @@ const questionnaire = [
   },
   {
     id: 2,
+    previousId: 1,
+    nextId: 3,
     type: 'question',
     content: {
       question: '샌프란시스코 Golden Gate Bridge에서 만난 이상형. 당장이라도 사랑에 빠질 것 같아요 ! 그 사람은 어떤 스타일일까요 ? ',
@@ -24,6 +28,8 @@ const questionnaire = [
   },
   {
     id: 3,
+    previousId: 2,
+    nextId: 4,
     type: 'question',
     content: {
       question: '그 / 그녀와의 데이트 전날, 당신은 무엇을 하고 있을까요?',
@@ -37,6 +43,8 @@ const questionnaire = [
   },
   {
     id: 4,
+    previousId: 3,
+    nextId: 5,
     type: 'overview',
     content: {
       title: 'Day2,',
@@ -45,6 +53,8 @@ const questionnaire = [
   },
   {
     id: 5,
+    previousId: 4,
+    nextId: null,
     type: 'question',
     content: {
       question: '투자자 앞에서 피칭을 합니다 당신은 무엇을 내세우시겠습니까',

--- a/src/pages/TestsPage.test.jsx
+++ b/src/pages/TestsPage.test.jsx
@@ -6,16 +6,16 @@ import { useSelector } from 'react-redux';
 
 import TestsPage from './TestsPage';
 
+import QUESTION from '../../fixtures/question';
+
 jest.mock('react-redux');
 
 test('TestsPage', () => {
-  beforeEach(() => {
-    useSelector.mockImplementation((selector) => selector({
-      currentTest: 1,
-      selectedAnswer: null,
-      savedAnswers: {},
-    }));
-  });
+  useSelector.mockImplementation((selector) => selector({
+    currentTest: QUESTION,
+    selectedAnswer: null,
+    savedAnswers: {},
+  }));
 
   render((
     <TestsPage />

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -6,24 +6,22 @@ import {
   saveAnswer,
 } from './slice';
 
+import OVERVIEW from '../fixtures/overview';
+
 describe('reducer', () => {
   describe('setCurrentTest', () => {
     it('changes current test', () => {
-      const previousState = {
-        currentTest: 0,
-      };
+      const previousState = { currentTest: null };
 
-      const { currentTest } = reducer(previousState, setCurrentTest(1));
+      const { currentTest } = reducer(previousState, setCurrentTest(OVERVIEW));
 
-      expect(currentTest).toEqual(1);
+      expect(currentTest).toEqual(OVERVIEW);
     });
   });
 
   describe('setSelectedAnswer', () => {
     it('changes the selected answer', () => {
-      const previousState = {
-        selectedAnswer: null,
-      };
+      const previousState = { selectedAnswer: null };
 
       const { selectedAnswer } = reducer(previousState, setSelectedAnswer(1));
 
@@ -33,9 +31,7 @@ describe('reducer', () => {
 
   describe('saveAnswer', () => {
     it('changes the savedAnswers', () => {
-      const previousState = {
-        savedAnswers: {},
-      };
+      const previousState = { savedAnswers: {} };
 
       const { savedAnswers } = reducer(previousState, saveAnswer({
         questionId: 2,

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -1,0 +1,7 @@
+export function getTest(testId) {
+  return { id: testId };
+}
+
+export function getInitialTest() {
+  return { id: 1 };
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,9 +4,11 @@ export function getTest(testId) {
   const test = questionnaire
     .find(({ id }) => id === testId);
 
-  return test || questionnaire[0];
+  return test;
 }
 
-export function xxx() {
-  // TODO: ...
+// TODO: Use getInitialTest when the user clicked `test` button in HomePage
+
+export function getInitialTest() {
+  return questionnaire[0];
 }

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,0 +1,22 @@
+import {
+  getTest,
+  getInitialTest,
+} from './api';
+
+describe('api', () => {
+  describe('getTest', () => {
+    it('returns question or overview', async () => {
+      const { id } = getTest(2);
+
+      expect(id).toEqual(2);
+    });
+  });
+
+  describe('getIntialTest', () => {
+    it('returns question or overview', async () => {
+      const { id } = getInitialTest();
+
+      expect(id).toEqual(1);
+    });
+  });
+});

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,17 +1,22 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import {
+  getTest,
+  getInitialTest,
+} from './services/api';
+
 const { actions, reducer } = createSlice({
   name: 'application',
   initialState: {
-    currentTest: 1,
+    currentTest: null,
     selectedAnswer: null,
     savedAnswers: {},
   },
   reducers: {
-    setCurrentTest(state, { payload: currentTest }) {
+    setCurrentTest(state, { payload: test }) {
       return {
         ...state,
-        currentTest,
+        currentTest: test,
       };
     },
     setSelectedAnswer(state, { payload: selectedAnswer }) {
@@ -39,5 +44,21 @@ export const {
   setSelectedAnswer,
   saveAnswer,
 } = actions;
+
+export function loadTest(id) {
+  return (dispatch) => {
+    const test = getTest(id);
+
+    dispatch(setCurrentTest(test));
+  };
+}
+
+export function loadInitialTest() {
+  return (dispatch) => {
+    const test = getInitialTest();
+
+    dispatch(setCurrentTest(test));
+  };
+}
 
 export default reducer;


### PR DESCRIPTION
**[변동사항]**
* `questionnaire` 데이터를 받아오는 방법을 변경했습니다.

  서버에서 받아오지는 않지만, 서버에서 받아오는 것처럼 코드를 작성하니 테스트가 더 용이하고 깔끔한 코드가 만들어지는 거 같아서 현재 코드와 같이 변경했습니다.

* `questionnaire` 데이터에 nextId, previousId를 추가했습니다. 
  
  저번에 해주신 피드백을 보고 어제 질문을 하려고 했는데, 오늘 좀 고민해보니 결국 questionnaire 데이터 자체에 저장하는 것이 좋겠다고 생각했습니다.

  > 중간에 question 하나가 삭제되면 어떻게 될까요?
  > 반드시 +1 -1 로 확정할 수 있을까요?
