### PR TITLE
Refactor api

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -3,16 +3,20 @@ import questionnaireImages from '../data/questionnaire-images';
 import scores from '../data/scores';
 import results from '../data/results';
 
-export const getTest = (testId) => questionnaire.find(({ id }) => id === testId);
+export const getTest = (id) => questionnaire.find((test) => id === test.id);
 
-// TODO: Refactor this function
-export const getTestImages = (testId) => questionnaireImages
-  .find(({ id }) => id === testId);
+export const getTestImages = (id) => {
+  const { images } = questionnaireImages.find(
+    (questionnaireImage) => questionnaireImage.id === id,
+  );
+
+  return images;
+};
 
 export const getInitialTest = () => questionnaire[0];
 
-export const getInitialTestImages = () => questionnaireImages[0];
+export const getInitialTestImages = () => questionnaireImages[0].images;
 
 export const getScores = () => scores;
 
-export const getResult = (resultId) => results.find(({ id }) => id === resultId);
+export const getResult = (id) => results.find((result) => id === result.id);

--- a/src/slice.js
+++ b/src/slice.js
@@ -65,7 +65,7 @@ export const {
 export function loadTest(id) {
   return (dispatch) => {
     const test = getTest(id);
-    const { images } = getTestImages(id);
+    const images = getTestImages(id);
 
     dispatch(setTest(test));
     dispatch(setTestImages(images));
@@ -75,7 +75,7 @@ export function loadTest(id) {
 export function loadInitialTest() {
   return (dispatch) => {
     const test = getInitialTest();
-    const { images } = getInitialTestImages();
+    const images = getInitialTestImages();
 
     dispatch(setTest(test));
     dispatch(setTestImages(images));


### PR DESCRIPTION
Use `id` as a parameter of the api functions
Make `getTestImages` and `getInitialTestImages` return destructured `images`